### PR TITLE
Add Docker image push workflow to GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,67 @@ jobs:
           path: dist/paideia.exe
           retention-days: 7
 
+  push-docker:
+    runs-on: ubuntu-latest
+    needs: [version-check, build-binaries]
+    if: needs.version-check.outputs.should-publish == 'true'
+    # Note: This job downloads its own copy of artifacts, so it's isolated from create-release job
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Download Linux ARM64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: paideia-linux-arm64
+          path: dist/
+
+      - name: Download Linux X64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: paideia-linux-x64
+          path: dist/
+
+      - name: Prepare binaries for Docker
+        run: |
+          # Handle nested artifact structure (artifacts may be downloaded as directories)
+          # IMPORTANT: Each job downloads its own isolated copy of artifacts,
+          # so file operations here won't affect the create-release job
+          if [ -d dist/paideia-linux-arm64 ] && [ -f dist/paideia-linux-arm64/paideia-linux-arm64 ]; then
+            mv dist/paideia-linux-arm64/paideia-linux-arm64 dist/paideia-linux-arm64.tmp
+            rm -rf dist/paideia-linux-arm64
+            mv dist/paideia-linux-arm64.tmp dist/paideia-linux-arm64
+          fi
+          
+          if [ -d dist/paideia-linux-x64 ] && [ -f dist/paideia-linux-x64/paideia-linux-x64 ]; then
+            mv dist/paideia-linux-x64/paideia-linux-x64 dist/paideia-linux-x64.tmp
+            rm -rf dist/paideia-linux-x64
+            mv dist/paideia-linux-x64.tmp dist/paideia-linux-x64
+          fi
+          
+          # Make binaries executable (push-docker.ts script will handle renaming x64 to amd64)
+          chmod +x dist/paideia-linux-arm64 dist/paideia-linux-x64 2>/dev/null || true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Push Docker images
+        run: bun scripts/push-docker.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_USERNAME: ${{ github.repository_owner }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
   create-release:
     runs-on: ubuntu-latest
     needs: [version-check, build-binaries]

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,7 @@ import { getPayload, type Migration as MigrationType } from "payload";
 import { RouterContextProvider } from "react-router";
 import { migrations } from "src/migrations";
 import { createStorage } from "unstorage";
+// biome-ignore lint/suspicious/noTsIgnore: <explanation>
 // @ts-ignore
 import lruCacheDriver from "unstorage/drivers/lru-cache";
 import { getHints } from "../app/utils/client-hints";


### PR DESCRIPTION
- Introduced a new job in the GitHub Actions workflow to build and push Docker images for Linux ARM64 and X64 binaries.
- Added steps for setting up Bun, installing dependencies, and preparing binaries for Docker.
- Enhanced binary handling to ensure correct permissions and structure before pushing to Docker Hub.
- Integrated Docker Buildx for multi-platform support, improving deployment capabilities.