### PR TITLE
Update GitHub Actions release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,10 @@ jobs:
     if: needs.version-check.outputs.should-publish == 'true'
     # Note: This job downloads its own copy of artifacts, so it's isolated from create-release job
 
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
- Added permissions for reading contents and writing packages in the release job of the GitHub Actions workflow.
- This change enhances the workflow's ability to manage artifacts and packages during the release process.